### PR TITLE
Pinned babel-loader@v9 to 9.1.3 (skip 9.2.0)

### DIFF
--- a/.changeset/lemon-moons-vanish.md
+++ b/.changeset/lemon-moons-vanish.md
@@ -1,0 +1,5 @@
+---
+"create-v2-addon-repo": patch
+---
+
+Pinned babel-loader@v9 to 9.1.3 (skip 9.2.0)

--- a/packages/create-v2-addon-repo/src/blueprints/package.json
+++ b/packages/create-v2-addon-repo/src/blueprints/package.json
@@ -21,5 +21,10 @@
   "engines": {
     "node": "18.* || >= 20",
     "pnpm": ">= 9"
+  },
+  "pnpm": {
+    "overrides": {
+      "@embroider/babel-loader-9>babel-loader": "9.1.3"
+    }
   }
 }

--- a/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/package.json
+++ b/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/package.json
@@ -21,5 +21,10 @@
   "engines": {
     "node": "18.* || >= 20",
     "pnpm": ">= 9"
+  },
+  "pnpm": {
+    "overrides": {
+      "@embroider/babel-loader-9>babel-loader": "9.1.3"
+    }
   }
 }


### PR DESCRIPTION
## Background

While testing `create-v2-addon-repo@0.10.3`, I found that the `start` and `test` commands for `docs-app` (a fresh Ember app) would error:

```sh
Module build failed (from ../../../../node_modules/.pnpm/thread-loader@3.0.4_webpack@5.94.0/node_modules/thread-loader/dist/cjs.js):
Thread Loader (Worker 0)
this.getLogger is not a function
    at PoolWorker.fromErrorObj (/node_modules/.pnpm/thread-loader@3.0.4_webpack@5.94.0/node_modules/thread-loader/dist/WorkerPool.js:346:12)
    at /node_modules/.pnpm/thread-loader@3.0.4_webpack@5.94.0/node_modules/thread-loader/dist/WorkerPool.js:219:29
    at mapSeries (/node_modules/.pnpm/neo-async@2.6.2/node_modules/neo-async/async.js:3625:14)
    at Object.loader (/node_modules/.pnpm/babel-loader@9.2.0_@babel+core@7.25.2_webpack@5.94.0/node_modules/babel-loader/lib/index.js:44:23)
    at Object.<anonymous> (/node_modules/.pnpm/babel-loader@9.2.0_@babel+core@7.25.2_webpack@5.94.0/node_modules/babel-loader/lib/index.js:39:12)
```

The error occurred for `0.10.1` so I could eliminate the codemod as the reason. I found out that `babel-loader` made a minor release about 40 minutes ago.

https://www.npmjs.com/package/babel-loader/v/9.2.0

