### PR TITLE
Removed pinning babel-loader@v9

### DIFF
--- a/.changeset/perfect-spies-tan.md
+++ b/.changeset/perfect-spies-tan.md
@@ -1,0 +1,5 @@
+---
+"create-v2-addon-repo": patch
+---
+
+Removed pinning babel-loader@v9

--- a/packages/create-v2-addon-repo/src/blueprints/package.json
+++ b/packages/create-v2-addon-repo/src/blueprints/package.json
@@ -21,10 +21,5 @@
   "engines": {
     "node": "18.* || >= 20",
     "pnpm": ">= 9"
-  },
-  "pnpm": {
-    "overrides": {
-      "@embroider/babel-loader-9>babel-loader": "9.1.3"
-    }
   }
 }

--- a/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/package.json
+++ b/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/package.json
@@ -21,10 +21,5 @@
   "engines": {
     "node": "18.* || >= 20",
     "pnpm": ">= 9"
-  },
-  "pnpm": {
-    "overrides": {
-      "@embroider/babel-loader-9>babel-loader": "9.1.3"
-    }
   }
 }


### PR DESCRIPTION
## Background

A temporary patch to https://github.com/babel/babel-loader/issues/1043 was released in [`babel-loader@9.2.1`](https://github.com/babel/babel-loader/releases/tag/v9.2.1).
