### PR TITLE
Patched #71

### DIFF
--- a/configs/ember-template-lint/index.cjs
+++ b/configs/ember-template-lint/index.cjs
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('@ijlee2-frontend-configs/ember-template-lint');

--- a/configs/ember-template-lint/package.json
+++ b/configs/ember-template-lint/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@shared-configs/ember-template-lint",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Configuration for ember-template-lint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ijlee2/embroider-toolbox.git"
+  },
+  "author": "Isaac J. Lee",
+  "type": "module",
+  "main": "index.cjs",
+  "scripts": {
+    "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
+    "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
+    "lint:js": "prettier \"**/*.{cjs,mjs}\" --check",
+    "lint:js:fix": "prettier \"**/*.{cjs,mjs}\" --write"
+  },
+  "dependencies": {
+    "@ijlee2-frontend-configs/ember-template-lint": "^0.4.0"
+  },
+  "devDependencies": {
+    "@shared-configs/prettier": "workspace:*",
+    "concurrently": "^9.1.2",
+    "prettier": "^3.5.0"
+  },
+  "peerDependencies": {
+    "ember-template-lint": "^6.1.0"
+  },
+  "peerDependenciesMeta": {
+    "ember-template-lint": {
+      "optional": false
+    }
+  },
+  "engines": {
+    "node": "18.* || >= 20"
+  }
+}

--- a/configs/ember-template-lint/prettier.config.mjs
+++ b/configs/ember-template-lint/prettier.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '@shared-configs/prettier';

--- a/configs/eslint/ember/app/index.js
+++ b/configs/eslint/ember/app/index.js
@@ -1,0 +1,1 @@
+export { default } from '@ijlee2-frontend-configs/eslint-config-ember/app';

--- a/configs/eslint/ember/eslint.config.mjs
+++ b/configs/eslint/ember/eslint.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '@shared-configs/eslint-config-node/javascript';

--- a/configs/eslint/ember/package.json
+++ b/configs/eslint/ember/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@shared-configs/eslint-config-ember",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Configuration for eslint (Ember)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ijlee2/embroider-toolbox.git"
+  },
+  "author": "Isaac J. Lee",
+  "type": "module",
+  "exports": {
+    "./app": "./app/index.js",
+    "./v1-addon": "./v1-addon/index.js",
+    "./v2-addon": "./v2-addon/index.js"
+  },
+  "scripts": {
+    "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
+    "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
+    "lint:js": "eslint . --cache",
+    "lint:js:fix": "eslint . --fix"
+  },
+  "dependencies": {
+    "@ijlee2-frontend-configs/eslint-config-ember": "^0.2.1"
+  },
+  "devDependencies": {
+    "@shared-configs/eslint-config-node": "workspace:*",
+    "@shared-configs/prettier": "workspace:*",
+    "concurrently": "^9.1.2",
+    "eslint": "^9.20.0",
+    "prettier": "^3.5.0"
+  },
+  "peerDependencies": {
+    "eslint": "^9.20.0",
+    "prettier": "^3.5.0",
+    "typescript": "^5.7.3"
+  },
+  "peerDependenciesMeta": {
+    "eslint": {
+      "optional": false
+    },
+    "prettier": {
+      "optional": false
+    },
+    "typescript": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": "18.* || >= 20"
+  }
+}

--- a/configs/eslint/ember/prettier.config.mjs
+++ b/configs/eslint/ember/prettier.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '@shared-configs/prettier';

--- a/configs/eslint/ember/v1-addon/index.js
+++ b/configs/eslint/ember/v1-addon/index.js
@@ -1,0 +1,1 @@
+export { default } from '@ijlee2-frontend-configs/eslint-config-ember/v1-addon';

--- a/configs/eslint/ember/v2-addon/index.js
+++ b/configs/eslint/ember/v2-addon/index.js
@@ -1,0 +1,1 @@
+export { default } from '@ijlee2-frontend-configs/eslint-config-ember/v2-addon';

--- a/configs/eslint/node/eslint.config.mjs
+++ b/configs/eslint/node/eslint.config.mjs
@@ -1,0 +1,1 @@
+export { default } from './javascript/index.js';

--- a/configs/eslint/node/javascript/index.js
+++ b/configs/eslint/node/javascript/index.js
@@ -1,0 +1,1 @@
+export { default } from '@ijlee2-frontend-configs/eslint-config-node/javascript';

--- a/configs/eslint/node/package.json
+++ b/configs/eslint/node/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@shared-configs/eslint-config-node",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Configuration for eslint (Node)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ijlee2/embroider-toolbox.git"
+  },
+  "author": "Isaac J. Lee",
+  "type": "module",
+  "exports": {
+    "./javascript": "./javascript/index.js",
+    "./typescript": "./typescript/index.js"
+  },
+  "scripts": {
+    "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
+    "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
+    "lint:js": "eslint . --cache",
+    "lint:js:fix": "eslint . --fix"
+  },
+  "dependencies": {
+    "@ijlee2-frontend-configs/eslint-config-node": "^0.2.1"
+  },
+  "devDependencies": {
+    "@shared-configs/prettier": "workspace:*",
+    "concurrently": "^9.1.2",
+    "eslint": "^9.20.0",
+    "prettier": "^3.5.0"
+  },
+  "peerDependencies": {
+    "eslint": "^9.20.0",
+    "prettier": "^3.5.0",
+    "typescript": "^5.7.3"
+  },
+  "peerDependenciesMeta": {
+    "eslint": {
+      "optional": false
+    },
+    "prettier": {
+      "optional": false
+    },
+    "typescript": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": "18.* || >= 20"
+  }
+}

--- a/configs/eslint/node/prettier.config.mjs
+++ b/configs/eslint/node/prettier.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '@shared-configs/prettier';

--- a/configs/eslint/node/typescript/index.js
+++ b/configs/eslint/node/typescript/index.js
@@ -1,0 +1,1 @@
+export { default } from '@ijlee2-frontend-configs/eslint-config-node/typescript';

--- a/configs/prettier/index.cjs
+++ b/configs/prettier/index.cjs
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('@ijlee2-frontend-configs/prettier');

--- a/configs/prettier/index.mjs
+++ b/configs/prettier/index.mjs
@@ -1,0 +1,1 @@
+export { default } from '@ijlee2-frontend-configs/prettier';

--- a/configs/prettier/package.json
+++ b/configs/prettier/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@shared-configs/prettier",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Configuration for prettier",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ijlee2/embroider-toolbox.git"
+  },
+  "author": "Isaac J. Lee",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.cjs"
+    }
+  },
+  "scripts": {
+    "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
+    "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
+    "lint:js": "prettier \"**/*.{cjs,mjs}\" --check",
+    "lint:js:fix": "prettier \"**/*.{cjs,mjs}\" --write"
+  },
+  "dependencies": {
+    "@ijlee2-frontend-configs/prettier": "^0.2.0"
+  },
+  "devDependencies": {
+    "concurrently": "^9.1.2",
+    "prettier": "^3.5.0"
+  },
+  "peerDependencies": {
+    "prettier": "^3.5.0"
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": false
+    }
+  },
+  "engines": {
+    "node": "18.* || >= 20"
+  }
+}

--- a/configs/prettier/prettier.config.mjs
+++ b/configs/prettier/prettier.config.mjs
@@ -1,0 +1,1 @@
+export { default } from './index.mjs';

--- a/configs/stylelint/css-modules/index.cjs
+++ b/configs/stylelint/css-modules/index.cjs
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('@ijlee2-frontend-configs/stylelint/css-modules');

--- a/configs/stylelint/css-modules/index.mjs
+++ b/configs/stylelint/css-modules/index.mjs
@@ -1,0 +1,1 @@
+export { default } from '@ijlee2-frontend-configs/stylelint/css-modules';

--- a/configs/stylelint/package.json
+++ b/configs/stylelint/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@shared-configs/stylelint",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Configuration for stylelint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ijlee2/embroider-toolbox.git"
+  },
+  "author": "Isaac J. Lee",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./css-modules/index.mjs",
+      "require": "./css-modules/index.cjs"
+    }
+  },
+  "scripts": {
+    "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
+    "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
+    "lint:js": "prettier \"**/*.{cjs,mjs}\" --check",
+    "lint:js:fix": "prettier \"**/*.{cjs,mjs}\" --write"
+  },
+  "dependencies": {
+    "@ijlee2-frontend-configs/stylelint": "^0.2.0"
+  },
+  "devDependencies": {
+    "@shared-configs/prettier": "workspace:*",
+    "concurrently": "^9.1.2",
+    "prettier": "^3.5.0"
+  },
+  "peerDependencies": {
+    "prettier": "^3.5.0",
+    "stylelint": "^16.14.1"
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": false
+    },
+    "stylelint": {
+      "optional": false
+    }
+  },
+  "engines": {
+    "node": "18.* || >= 20"
+  }
+}

--- a/configs/stylelint/prettier.config.mjs
+++ b/configs/stylelint/prettier.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '@ijlee2-frontend-configs/prettier';

--- a/configs/typescript/ember/index.json
+++ b/configs/typescript/ember/index.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@ijlee2-frontend-configs/typescript/ember"
+}

--- a/configs/typescript/node18/index.json
+++ b/configs/typescript/node18/index.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@ijlee2-frontend-configs/typescript/node18"
+}

--- a/configs/typescript/package.json
+++ b/configs/typescript/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@shared-configs/typescript",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Configuration for typescript",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ijlee2/embroider-toolbox.git"
+  },
+  "author": "Isaac J. Lee",
+  "type": "module",
+  "exports": {
+    "./ember": "./ember/index.json",
+    "./node18": "./node18/index.json"
+  },
+  "scripts": {
+    "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
+    "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
+    "lint:js": "prettier \"**/*.{cjs,json,mjs}\" --check",
+    "lint:js:fix": "prettier \"**/*.{cjs,json,mjs}\" --write"
+  },
+  "dependencies": {
+    "@ijlee2-frontend-configs/typescript": "^0.3.0"
+  },
+  "devDependencies": {
+    "@shared-configs/prettier": "workspace:*",
+    "concurrently": "^9.1.2",
+    "prettier": "^3.5.0"
+  },
+  "peerDependencies": {
+    "typescript": "^5.7.3"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": false
+    }
+  },
+  "engines": {
+    "node": "18.* || >= 20"
+  }
+}

--- a/configs/typescript/prettier.config.mjs
+++ b/configs/typescript/prettier.config.mjs
@@ -1,0 +1,1 @@
+export { default } from '@ijlee2-frontend-configs/prettier';

--- a/packages/analyze-ember-project-dependencies/eslint.config.mjs
+++ b/packages/analyze-ember-project-dependencies/eslint.config.mjs
@@ -1,4 +1,4 @@
-import baseConfiguration from '@ijlee2-frontend-configs/eslint-config-node/typescript';
+import baseConfiguration from '@shared-configs/eslint-config-node/typescript';
 
 export default [
   {

--- a/packages/analyze-ember-project-dependencies/package.json
+++ b/packages/analyze-ember-project-dependencies/package.json
@@ -42,9 +42,9 @@
   },
   "devDependencies": {
     "@codemod-utils/tests": "^1.1.10",
-    "@ijlee2-frontend-configs/eslint-config-node": "^0.2.1",
-    "@ijlee2-frontend-configs/prettier": "^0.2.0",
-    "@ijlee2-frontend-configs/typescript": "^0.3.0",
+    "@shared-configs/eslint-config-node": "workspace:*",
+    "@shared-configs/prettier": "workspace:*",
+    "@shared-configs/typescript": "workspace:*",
     "@sondr3/minitest": "^0.1.2",
     "@types/node": "^18.19.75",
     "@types/yargs": "^17.0.33",

--- a/packages/analyze-ember-project-dependencies/prettier.config.mjs
+++ b/packages/analyze-ember-project-dependencies/prettier.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '@ijlee2-frontend-configs/prettier';
+export { default } from '@shared-configs/prettier';

--- a/packages/analyze-ember-project-dependencies/tsconfig.build.json
+++ b/packages/analyze-ember-project-dependencies/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@ijlee2-frontend-configs/typescript/node18",
+  "extends": "@shared-configs/typescript/node18",
   "compilerOptions": {
     "declaration": false,
     "outDir": "dist"

--- a/packages/analyze-ember-project-dependencies/tsconfig.json
+++ b/packages/analyze-ember-project-dependencies/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@ijlee2-frontend-configs/typescript/node18",
+  "extends": "@shared-configs/typescript/node18",
   "compilerOptions": {
     "declaration": false,
     "outDir": "dist-for-testing"

--- a/packages/blueprints-v2-addon/eslint.config.mjs
+++ b/packages/blueprints-v2-addon/eslint.config.mjs
@@ -1,4 +1,4 @@
-import baseConfiguration from '@ijlee2-frontend-configs/eslint-config-node/typescript';
+import baseConfiguration from '@shared-configs/eslint-config-node/typescript';
 
 export default [
   {

--- a/packages/blueprints-v2-addon/package.json
+++ b/packages/blueprints-v2-addon/package.json
@@ -44,9 +44,9 @@
   },
   "devDependencies": {
     "@codemod-utils/tests": "^1.1.10",
-    "@ijlee2-frontend-configs/eslint-config-node": "^0.2.1",
-    "@ijlee2-frontend-configs/prettier": "^0.2.0",
-    "@ijlee2-frontend-configs/typescript": "^0.3.0",
+    "@shared-configs/eslint-config-node": "workspace:*",
+    "@shared-configs/prettier": "workspace:*",
+    "@shared-configs/typescript": "workspace:*",
     "@sondr3/minitest": "^0.1.2",
     "@types/node": "^18.19.75",
     "@types/yargs": "^17.0.33",

--- a/packages/blueprints-v2-addon/prettier.config.mjs
+++ b/packages/blueprints-v2-addon/prettier.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '@ijlee2-frontend-configs/prettier';
+export { default } from '@shared-configs/prettier';

--- a/packages/blueprints-v2-addon/tsconfig.build.json
+++ b/packages/blueprints-v2-addon/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@ijlee2-frontend-configs/typescript/node18",
+  "extends": "@shared-configs/typescript/node18",
   "compilerOptions": {
     "declaration": false,
     "outDir": "dist"

--- a/packages/blueprints-v2-addon/tsconfig.json
+++ b/packages/blueprints-v2-addon/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@ijlee2-frontend-configs/typescript/node18",
+  "extends": "@shared-configs/typescript/node18",
   "compilerOptions": {
     "declaration": false,
     "outDir": "dist-for-testing"

--- a/packages/create-v2-addon-repo/eslint.config.mjs
+++ b/packages/create-v2-addon-repo/eslint.config.mjs
@@ -1,4 +1,4 @@
-import baseConfiguration from '@ijlee2-frontend-configs/eslint-config-node/typescript';
+import baseConfiguration from '@shared-configs/eslint-config-node/typescript';
 
 export default [
   {

--- a/packages/create-v2-addon-repo/package.json
+++ b/packages/create-v2-addon-repo/package.json
@@ -38,9 +38,9 @@
   },
   "devDependencies": {
     "@codemod-utils/tests": "^1.1.10",
-    "@ijlee2-frontend-configs/eslint-config-node": "^0.2.1",
-    "@ijlee2-frontend-configs/prettier": "^0.2.0",
-    "@ijlee2-frontend-configs/typescript": "^0.3.0",
+    "@shared-configs/eslint-config-node": "workspace:*",
+    "@shared-configs/prettier": "workspace:*",
+    "@shared-configs/typescript": "workspace:*",
     "@sondr3/minitest": "^0.1.2",
     "@types/node": "^18.19.75",
     "@types/yargs": "^17.0.33",

--- a/packages/create-v2-addon-repo/prettier.config.mjs
+++ b/packages/create-v2-addon-repo/prettier.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '@ijlee2-frontend-configs/prettier';
+export { default } from '@shared-configs/prettier';

--- a/packages/create-v2-addon-repo/tsconfig.build.json
+++ b/packages/create-v2-addon-repo/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@ijlee2-frontend-configs/typescript/node18",
+  "extends": "@shared-configs/typescript/node18",
   "compilerOptions": {
     "declaration": false,
     "outDir": "dist"

--- a/packages/create-v2-addon-repo/tsconfig.json
+++ b/packages/create-v2-addon-repo/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@ijlee2-frontend-configs/typescript/node18",
+  "extends": "@shared-configs/typescript/node18",
   "compilerOptions": {
     "declaration": false,
     "outDir": "dist-for-testing"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,108 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
 
+  configs/ember-template-lint:
+    dependencies:
+      '@ijlee2-frontend-configs/ember-template-lint':
+        specifier: ^0.4.0
+        version: 0.4.0(prettier@3.5.0)
+    devDependencies:
+      '@shared-configs/prettier':
+        specifier: workspace:*
+        version: link:../prettier
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.1.2
+      prettier:
+        specifier: ^3.5.0
+        version: 3.5.0
+
+  configs/eslint/ember:
+    dependencies:
+      '@ijlee2-frontend-configs/eslint-config-ember':
+        specifier: ^0.2.1
+        version: 0.2.1(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0)(prettier@3.5.0)(typescript@5.7.3)
+    devDependencies:
+      '@shared-configs/eslint-config-node':
+        specifier: workspace:*
+        version: link:../node
+      '@shared-configs/prettier':
+        specifier: workspace:*
+        version: link:../../prettier
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.1.2
+      eslint:
+        specifier: ^9.20.0
+        version: 9.20.0
+      prettier:
+        specifier: ^3.5.0
+        version: 3.5.0
+
+  configs/eslint/node:
+    dependencies:
+      '@ijlee2-frontend-configs/eslint-config-node':
+        specifier: ^0.2.1
+        version: 0.2.1(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0)(prettier@3.5.0)(typescript@5.7.3)
+    devDependencies:
+      '@shared-configs/prettier':
+        specifier: workspace:*
+        version: link:../../prettier
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.1.2
+      eslint:
+        specifier: ^9.20.0
+        version: 9.20.0
+      prettier:
+        specifier: ^3.5.0
+        version: 3.5.0
+
+  configs/prettier:
+    dependencies:
+      '@ijlee2-frontend-configs/prettier':
+        specifier: ^0.2.0
+        version: 0.2.0(prettier@3.5.0)
+    devDependencies:
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.1.2
+      prettier:
+        specifier: ^3.5.0
+        version: 3.5.0
+
+  configs/stylelint:
+    dependencies:
+      '@ijlee2-frontend-configs/stylelint':
+        specifier: ^0.2.0
+        version: 0.2.0(prettier@3.5.0)
+    devDependencies:
+      '@shared-configs/prettier':
+        specifier: workspace:*
+        version: link:../prettier
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.1.2
+      prettier:
+        specifier: ^3.5.0
+        version: 3.5.0
+
+  configs/typescript:
+    dependencies:
+      '@ijlee2-frontend-configs/typescript':
+        specifier: ^0.3.0
+        version: 0.3.0(typescript@5.7.3)
+    devDependencies:
+      '@shared-configs/prettier':
+        specifier: workspace:*
+        version: link:../prettier
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.1.2
+      prettier:
+        specifier: ^3.5.0
+        version: 3.5.0
+
   packages/analyze-ember-project-dependencies:
     dependencies:
       '@codemod-utils/ast-javascript':
@@ -48,15 +150,15 @@ importers:
       '@codemod-utils/tests':
         specifier: ^1.1.10
         version: 1.1.10(@sondr3/minitest@0.1.2)
-      '@ijlee2-frontend-configs/eslint-config-node':
-        specifier: ^0.2.1
-        version: 0.2.1(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0)(prettier@3.5.0)(typescript@5.7.3)
-      '@ijlee2-frontend-configs/prettier':
-        specifier: ^0.2.0
-        version: 0.2.0(prettier@3.5.0)
-      '@ijlee2-frontend-configs/typescript':
-        specifier: ^0.3.0
-        version: 0.3.0(typescript@5.7.3)
+      '@shared-configs/eslint-config-node':
+        specifier: workspace:*
+        version: link:../../configs/eslint/node
+      '@shared-configs/prettier':
+        specifier: workspace:*
+        version: link:../../configs/prettier
+      '@shared-configs/typescript':
+        specifier: workspace:*
+        version: link:../../configs/typescript
       '@sondr3/minitest':
         specifier: ^0.1.2
         version: 0.1.2
@@ -103,15 +205,15 @@ importers:
       '@codemod-utils/tests':
         specifier: ^1.1.10
         version: 1.1.10(@sondr3/minitest@0.1.2)
-      '@ijlee2-frontend-configs/eslint-config-node':
-        specifier: ^0.2.1
-        version: 0.2.1(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0)(prettier@3.5.0)(typescript@5.7.3)
-      '@ijlee2-frontend-configs/prettier':
-        specifier: ^0.2.0
-        version: 0.2.0(prettier@3.5.0)
-      '@ijlee2-frontend-configs/typescript':
-        specifier: ^0.3.0
-        version: 0.3.0(typescript@5.7.3)
+      '@shared-configs/eslint-config-node':
+        specifier: workspace:*
+        version: link:../../configs/eslint/node
+      '@shared-configs/prettier':
+        specifier: workspace:*
+        version: link:../../configs/prettier
+      '@shared-configs/typescript':
+        specifier: workspace:*
+        version: link:../../configs/typescript
       '@sondr3/minitest':
         specifier: ^0.1.2
         version: 0.1.2
@@ -152,15 +254,15 @@ importers:
       '@codemod-utils/tests':
         specifier: ^1.1.10
         version: 1.1.10(@sondr3/minitest@0.1.2)
-      '@ijlee2-frontend-configs/eslint-config-node':
-        specifier: ^0.2.1
-        version: 0.2.1(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0)(prettier@3.5.0)(typescript@5.7.3)
-      '@ijlee2-frontend-configs/prettier':
-        specifier: ^0.2.0
-        version: 0.2.0(prettier@3.5.0)
-      '@ijlee2-frontend-configs/typescript':
-        specifier: ^0.3.0
-        version: 0.3.0(typescript@5.7.3)
+      '@shared-configs/eslint-config-node':
+        specifier: workspace:*
+        version: link:../../configs/eslint/node
+      '@shared-configs/prettier':
+        specifier: workspace:*
+        version: link:../../configs/prettier
+      '@shared-configs/typescript':
+        specifier: workspace:*
+        version: link:../../configs/typescript
       '@sondr3/minitest':
         specifier: ^0.1.2
         version: 0.1.2
@@ -212,8 +314,22 @@ packages:
     resolution: {integrity: sha512-ef383X5++iZHWAXX0SXQR6ZyQhw/0KtTkrTz61WXRhFM6dhpHulO/RJz79L8S6ugZHJkOOkUrUdxgdF2YiPFnA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-annotate-as-pure@7.25.9':
+    resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-compilation-targets@7.26.5':
     resolution: {integrity: sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-create-class-features-plugin@7.25.9':
+    resolution: {integrity: sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-member-expression-to-functions@7.25.9':
+    resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.25.9':
@@ -225,6 +341,24 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  '@babel/helper-optimise-call-expression@7.25.9':
+    resolution: {integrity: sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.26.5':
+    resolution: {integrity: sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.26.5':
+    resolution: {integrity: sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
+    resolution: {integrity: sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.25.9':
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
@@ -246,6 +380,18 @@ packages:
     resolution: {integrity: sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/plugin-proposal-decorators@7.25.9':
+    resolution: {integrity: sha512-smkNLL/O1ezy9Nhy4CNosc4Va+1wo5w4gzSZeLe6y6dM4mmHfYOCPolXQPHQxonZCF+ZyebxN9vqOolkYrSn5g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-decorators@7.25.9':
+    resolution: {integrity: sha512-ryzI0McXUPJnRCvMo4lumIKZUzhYUO/ScI+Mz4YVaTLt04DHNSjEUjKVvbzQjZFLuod/cYEc07mJWhzl6v4DPg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/runtime@7.26.7':
     resolution: {integrity: sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==}
@@ -351,6 +497,9 @@ packages:
     peerDependencies:
       '@sondr3/minitest': ^0.1.2
 
+  '@ember-data/rfc395-data@0.0.4':
+    resolution: {integrity: sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==}
+
   '@eslint-community/eslint-utils@4.4.1':
     resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -398,17 +547,29 @@ packages:
   '@glimmer/interfaces@0.84.3':
     resolution: {integrity: sha512-dk32ykoNojt0mvEaIW6Vli5MGTbQo58uy3Epj7ahCgTHmWOKuw/0G83f2UmFprRwFx689YTXG38I/vbpltEjzg==}
 
+  '@glimmer/interfaces@0.92.3':
+    resolution: {integrity: sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==}
+
   '@glimmer/reference@0.84.3':
     resolution: {integrity: sha512-lV+p/aWPVC8vUjmlvYVU7WQJsLh319SdXuAWoX/SE3pq340BJlAJiEcAc6q52y9JNhT57gMwtjMX96W5Xcx/qw==}
 
   '@glimmer/syntax@0.84.3':
     resolution: {integrity: sha512-ioVbTic6ZisLxqTgRBL2PCjYZTFIwobifCustrozRU2xGDiYvVIL0vt25h2c1ioDsX59UgVlDkIK4YTAQQSd2A==}
 
+  '@glimmer/syntax@0.92.3':
+    resolution: {integrity: sha512-7wPKQmULyXCYf0KvbPmfrs/skPISH2QGR9atCnmDWnHyLv5SSZVLm1P0Ctrpta6+Ci3uGQb7hGk0IjsLEavcYQ==}
+
   '@glimmer/util@0.84.3':
     resolution: {integrity: sha512-qFkh6s16ZSRuu2rfz3T4Wp0fylFj3HBsONGXQcrAdZjdUaIS6v3pNj6mecJ71qRgcym9Hbaq/7/fefIwECUiKw==}
 
+  '@glimmer/util@0.92.3':
+    resolution: {integrity: sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==}
+
   '@glimmer/validator@0.84.3':
     resolution: {integrity: sha512-RTBV4TokUB0vI31UC7ikpV7lOYpWUlyqaKV//pRC4pexYMlmqnVhkFrdiimB/R1XyNdUOQUmnIAcdic39NkbhQ==}
+
+  '@glimmer/wire-format@0.92.3':
+    resolution: {integrity: sha512-gFz81Q9+V7Xs0X8mSq6y8qacHm0dPaGJo2/Bfcsdow1hLOKNgTCLr4XeDBhRML8f6I6Gk9ugH4QDxyIOXOpC4w==}
 
   '@handlebars/parser@2.0.0':
     resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}
@@ -433,6 +594,23 @@ packages:
     resolution: {integrity: sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==}
     engines: {node: '>=18.18'}
 
+  '@ijlee2-frontend-configs/ember-template-lint@0.4.0':
+    resolution: {integrity: sha512-xYlW7PnfO6vo780u2nil+6ql/4kQjYjT0v9W2GVQxX0L4du76L1+KTIwKTP7uqxK8C5ytH2zoE+pGW2NG1vHaw==}
+    engines: {node: 18.* || >= 20}
+    peerDependencies:
+      ember-template-lint: ^6.0.0
+
+  '@ijlee2-frontend-configs/eslint-config-ember@0.2.1':
+    resolution: {integrity: sha512-pEfiHMFKUgBohnIoEx9i5/DuOOOLC2DWT9hZ/5nyYMYtNQsgZMrcBNXNfeAmonTF+AHnzCKzrjmDy8PTxehX6w==}
+    engines: {node: 18.* || >= 20}
+    peerDependencies:
+      eslint: ^9.0.0
+      prettier: ^3.0.0
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@ijlee2-frontend-configs/eslint-config-node@0.2.1':
     resolution: {integrity: sha512-WUeQJgeSGiy1SqHOFB2RjO4Ca91iENK+IpFYOuQt2DBVcGfp+QqKCqr8H+cNDTY97CNDr61KXKBfgBTzHcnLlw==}
     engines: {node: 18.* || >= 20}
@@ -449,6 +627,13 @@ packages:
     engines: {node: 18.* || >= 20}
     peerDependencies:
       prettier: ^3.0.0
+
+  '@ijlee2-frontend-configs/stylelint@0.2.0':
+    resolution: {integrity: sha512-a1HKw+wiPIX6vExBxGS0lHmDr/4cPDQQ+lcvhJl/1aNLccLSaVKORsj6UEzfe6lAaym41DPc7P76IabpqU5OTg==}
+    engines: {node: 18.* || >= 20}
+    peerDependencies:
+      prettier: ^3.0.0
+      stylelint: ^16.0.0
 
   '@ijlee2-frontend-configs/typescript@0.3.0':
     resolution: {integrity: sha512-urEVOa4MswsBjHXD9e1mafiLg/Fp16M4c6Vc4l3uQUFC8YD5YjYu2VOIG1EW7R9b/qr8s428Y9sB1w9wNlxq6w==}
@@ -510,6 +695,11 @@ packages:
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@prettier/sync@0.2.1':
+    resolution: {integrity: sha512-7ls1R6//+GPYD9vof1XaL5psViv83CwpdwlS8oUkWldYgbPhzZ3WgxIQMWqGyBmWPmoBfQg8C7jj7KI/ZuDHhQ==}
+    peerDependencies:
+      prettier: ^3.0.0
 
   '@simple-dom/interface@1.4.0':
     resolution: {integrity: sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==}
@@ -810,6 +1000,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
 
@@ -856,11 +1050,34 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dot-case@3.0.4:
+    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   electron-to-chromium@1.5.92:
     resolution: {integrity: sha512-BeHgmNobs05N1HMmMZ7YIuHfYBGlq/UmvlsTgg+fsbFs9xVMj+xJHFg19GN04+9Q+r8Xnh9LXqaYIyEWElnNgQ==}
+
+  ember-eslint-parser@0.5.9:
+    resolution: {integrity: sha512-IW4/3cEiFp49M2LiKyzi7VcT1egogOe8UxQ9eUKTooenC7Q4qNhzTD6rOZ8j51m8iJC+8hCzjbNCa3K4CN0Hhg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.23.6
+      '@typescript-eslint/parser': '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+
+  ember-rfc176-data@0.3.18:
+    resolution: {integrity: sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==}
+
+  ember-template-lint-plugin-prettier@5.0.0:
+    resolution: {integrity: sha512-aXUYM4yuIdPZ80+AsAU8QBwGSJJ/aAkRsNcQ5vI5HmXiBjzHlDc/ZhmP6iVcYuCmoA/3iKcssMAYwIDbuby4pg==}
+    engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      ember-template-lint: '>= 4.0.0'
+      prettier: '>= 3.0.0'
 
   ember-template-recast@6.1.5:
     resolution: {integrity: sha512-VnRN8FzEHQnw/5rCv6Wnq8MVYXbGQbFY+rEufvWV+FO/IsxMahGEud4MYWtTA2q8iG+qJFrDQefNvQ//7MI7Qw==}
@@ -920,6 +1137,16 @@ packages:
       eslint-plugin-import-x:
         optional: true
 
+  eslint-plugin-ember@12.5.0:
+    resolution: {integrity: sha512-DBUzsaKWDVXsujAZPpRir0O7owdlCoVzZmtaJm7g7iQeSrNtcRWI7AItsTqKSsws1XeAySH0sPsQItMdDCb9Fg==}
+    engines: {node: 18.* || 20.* || >= 21}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '>= 8'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+
   eslint-plugin-es-x@7.8.0:
     resolution: {integrity: sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -952,6 +1179,10 @@ packages:
       eslint-config-prettier:
         optional: true
 
+  eslint-plugin-qunit@8.1.2:
+    resolution: {integrity: sha512-2gDQdHlQW8GVXD7YYkO8vbm9Ldc60JeGMuQN5QlD48OeZ8znBvvoHWZZMeXjvoDPReGaLEvyuWrDtrI8bDbcqw==}
+    engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
+
   eslint-plugin-simple-import-sort@12.1.1:
     resolution: {integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==}
     peerDependencies:
@@ -969,9 +1200,19 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
+  eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   eslint-scope@8.2.0:
     resolution: {integrity: sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-utils@3.0.0:
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
 
   eslint-visitor-keys@2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
@@ -1158,6 +1399,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  html-tags@3.3.1:
+    resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
+    engines: {node: '>=8'}
+
   human-id@1.0.2:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
 
@@ -1282,6 +1527,12 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.kebabcase@4.1.1:
+    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -1295,6 +1546,9 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -1304,6 +1558,12 @@ packages:
   matcher-collection@2.0.1:
     resolution: {integrity: sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  mathml-tag-names@2.1.3:
+    resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1338,11 +1598,19 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nanoid@3.3.8:
+    resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -1443,6 +1711,15 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  postcss-sorting@8.0.2:
+    resolution: {integrity: sha512-M9dkSrmU00t/jK7rF6BZSZauA5MAaBW4i5EnJXspMwt4iqTh/L9j6fgMnbElEOfyRyfLfVbIHj/R52zHzAPe1Q==}
+    peerDependencies:
+      postcss: ^8.4.20
+
+  postcss@8.5.1:
+    resolution: {integrity: sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -1492,6 +1769,10 @@ packages:
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
+
+  requireindex@1.2.0:
+    resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
+    engines: {node: '>=0.10.5'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1564,6 +1845,13 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  snake-case@3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -1604,6 +1892,30 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  stylelint-config-recommended@15.0.0:
+    resolution: {integrity: sha512-9LejMFsat7L+NXttdHdTq94byn25TD+82bzGRiV1Pgasl99pWnwipXS5DguTpp3nP1XjvLXVnEJIuYBfsRjRkA==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      stylelint: ^16.13.0
+
+  stylelint-config-standard@37.0.0:
+    resolution: {integrity: sha512-+6eBlbSTrOn/il2RlV0zYGQwRTkr+WtzuVSs1reaWGObxnxLpbcspCUYajVQHonVfxVw2U+h42azGhrBvcg8OA==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      stylelint: ^16.13.0
+
+  stylelint-order@6.0.4:
+    resolution: {integrity: sha512-0UuKo4+s1hgQ/uAxlYU4h0o0HS4NiQDud0NAUNI0aa8FJdmYHA5ZZTFHiV5FpmE3071e9pZx5j0QpVJW5zOCUA==}
+    peerDependencies:
+      stylelint: ^14.0.0 || ^15.0.0 || ^16.0.1
+
+  stylelint-prettier@5.0.3:
+    resolution: {integrity: sha512-B6V0oa35ekRrKZlf+6+jA+i50C4GXJ7X1PPmoCqSUoXN6BrNF6NhqqhanvkLjqw2qgvrS0wjdpeC+Tn06KN3jw==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      prettier: '>=3.0.0'
+      stylelint: '>=16.0.0'
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1615,6 +1927,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svg-tags@1.0.0:
+    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
   synckit@0.9.2:
     resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
@@ -1824,6 +2139,10 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
+  '@babel/helper-annotate-as-pure@7.25.9':
+    dependencies:
+      '@babel/types': 7.26.8
+
   '@babel/helper-compilation-targets@7.26.5':
     dependencies:
       '@babel/compat-data': 7.26.5
@@ -1831,6 +2150,26 @@ snapshots:
       browserslist: 4.24.4
       lru-cache: 5.1.1
       semver: 6.3.1
+
+  '@babel/helper-create-class-features-plugin@7.25.9(@babel/core@7.26.8)':
+    dependencies:
+      '@babel/core': 7.26.8
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/helper-replace-supers': 7.26.5(@babel/core@7.26.8)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/traverse': 7.26.8
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-member-expression-to-functions@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.26.8
+      '@babel/types': 7.26.8
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-module-imports@7.25.9':
     dependencies:
@@ -1848,6 +2187,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-optimise-call-expression@7.25.9':
+    dependencies:
+      '@babel/types': 7.26.8
+
+  '@babel/helper-plugin-utils@7.26.5': {}
+
+  '@babel/helper-replace-supers@7.26.5(@babel/core@7.26.8)':
+    dependencies:
+      '@babel/core': 7.26.8
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/traverse': 7.26.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.26.8
+      '@babel/types': 7.26.8
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.25.9': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
@@ -1862,6 +2223,20 @@ snapshots:
   '@babel/parser@7.26.8':
     dependencies:
       '@babel/types': 7.26.8
+
+  '@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.26.8)':
+    dependencies:
+      '@babel/core': 7.26.8
+      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.26.8)
+      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.26.8)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-syntax-decorators@7.25.9(@babel/core@7.26.8)':
+    dependencies:
+      '@babel/core': 7.26.8
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/runtime@7.26.7':
     dependencies:
@@ -2070,6 +2445,8 @@ snapshots:
       fixturify: 3.0.0
       glob: 10.4.5
 
+  '@ember-data/rfc395-data@0.0.4': {}
+
   '@eslint-community/eslint-utils@4.4.1(eslint@9.20.0)':
     dependencies:
       eslint: 9.20.0
@@ -2126,6 +2503,10 @@ snapshots:
     dependencies:
       '@simple-dom/interface': 1.4.0
 
+  '@glimmer/interfaces@0.92.3':
+    dependencies:
+      '@simple-dom/interface': 1.4.0
+
   '@glimmer/reference@0.84.3':
     dependencies:
       '@glimmer/env': 0.1.7
@@ -2141,16 +2522,34 @@ snapshots:
       '@handlebars/parser': 2.0.0
       simple-html-tokenizer: 0.5.11
 
+  '@glimmer/syntax@0.92.3':
+    dependencies:
+      '@glimmer/interfaces': 0.92.3
+      '@glimmer/util': 0.92.3
+      '@glimmer/wire-format': 0.92.3
+      '@handlebars/parser': 2.0.0
+      simple-html-tokenizer: 0.5.11
+
   '@glimmer/util@0.84.3':
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/interfaces': 0.84.3
       '@simple-dom/interface': 1.4.0
 
+  '@glimmer/util@0.92.3':
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/interfaces': 0.92.3
+
   '@glimmer/validator@0.84.3':
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/global-context': 0.84.3
+
+  '@glimmer/wire-format@0.92.3':
+    dependencies:
+      '@glimmer/interfaces': 0.92.3
+      '@glimmer/util': 0.92.3
 
   '@handlebars/parser@2.0.0': {}
 
@@ -2166,6 +2565,39 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.1': {}
+
+  '@ijlee2-frontend-configs/ember-template-lint@0.4.0(prettier@3.5.0)':
+    dependencies:
+      ember-template-lint-plugin-prettier: 5.0.0(prettier@3.5.0)
+    transitivePeerDependencies:
+      - prettier
+
+  '@ijlee2-frontend-configs/eslint-config-ember@0.2.1(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0)(prettier@3.5.0)(typescript@5.7.3)':
+    dependencies:
+      '@babel/core': 7.26.8
+      '@babel/eslint-parser': 7.26.8(@babel/core@7.26.8)(eslint@9.20.0)
+      '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.8)
+      '@eslint/js': 9.20.0
+      eslint: 9.20.0
+      eslint-config-prettier: 10.0.1(eslint@9.20.0)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import-x@4.6.1(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0)
+      eslint-plugin-ember: 12.5.0(@babel/core@7.26.8)(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0)
+      eslint-plugin-import-x: 4.6.1(eslint@9.20.0)(typescript@5.7.3)
+      eslint-plugin-n: 17.15.1(eslint@9.20.0)
+      eslint-plugin-prettier: 5.2.3(eslint-config-prettier@10.0.1(eslint@9.20.0))(eslint@9.20.0)(prettier@3.5.0)
+      eslint-plugin-qunit: 8.1.2(eslint@9.20.0)
+      eslint-plugin-simple-import-sort: 12.1.1(eslint@9.20.0)
+      eslint-plugin-typescript-sort-keys: 3.3.0(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0)(typescript@5.7.3)
+      globals: 15.14.0
+      prettier: 3.5.0
+      typescript-eslint: 8.23.0(eslint@9.20.0)(typescript@5.7.3)
+    optionalDependencies:
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - '@types/eslint'
+      - '@typescript-eslint/parser'
+      - eslint-plugin-import
+      - supports-color
 
   '@ijlee2-frontend-configs/eslint-config-node@0.2.1(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0)(prettier@3.5.0)(typescript@5.7.3)':
     dependencies:
@@ -2197,6 +2629,13 @@ snapshots:
       prettier-plugin-ember-template-tag: 2.0.4(prettier@3.5.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@ijlee2-frontend-configs/stylelint@0.2.0(prettier@3.5.0)':
+    dependencies:
+      prettier: 3.5.0
+      stylelint-config-standard: 37.0.0
+      stylelint-order: 6.0.4
+      stylelint-prettier: 5.0.3(prettier@3.5.0)
 
   '@ijlee2-frontend-configs/typescript@0.3.0(typescript@5.7.3)':
     dependencies:
@@ -2271,6 +2710,10 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.1.1': {}
+
+  '@prettier/sync@0.2.1(prettier@3.5.0)':
+    dependencies:
+      prettier: 3.5.0
 
   '@simple-dom/interface@1.4.0': {}
 
@@ -2600,6 +3043,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
   dataloader@1.4.0: {}
 
   debug@2.6.9:
@@ -2630,9 +3078,37 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dot-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
+
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.92: {}
+
+  ember-eslint-parser@0.5.9(@babel/core@7.26.8)(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0):
+    dependencies:
+      '@babel/core': 7.26.8
+      '@babel/eslint-parser': 7.26.8(@babel/core@7.26.8)(eslint@9.20.0)
+      '@glimmer/syntax': 0.92.3
+      content-tag: 2.0.3
+      eslint-scope: 7.2.2
+      html-tags: 3.3.1
+      mathml-tag-names: 2.1.3
+      svg-tags: 1.0.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.23.0(eslint@9.20.0)(typescript@5.7.3)
+    transitivePeerDependencies:
+      - eslint
+
+  ember-rfc176-data@0.3.18: {}
+
+  ember-template-lint-plugin-prettier@5.0.0(prettier@3.5.0):
+    dependencies:
+      '@prettier/sync': 0.2.1(prettier@3.5.0)
+      prettier: 3.5.0
+      prettier-linter-helpers: 1.0.0
 
   ember-template-recast@6.1.5:
     dependencies:
@@ -2703,6 +3179,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-plugin-ember@12.5.0(@babel/core@7.26.8)(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0):
+    dependencies:
+      '@ember-data/rfc395-data': 0.0.4
+      css-tree: 3.1.0
+      ember-eslint-parser: 0.5.9(@babel/core@7.26.8)(@typescript-eslint/parser@8.23.0(eslint@9.20.0)(typescript@5.7.3))(eslint@9.20.0)
+      ember-rfc176-data: 0.3.18
+      eslint: 9.20.0
+      eslint-utils: 3.0.0(eslint@9.20.0)
+      estraverse: 5.3.0
+      lodash.camelcase: 4.3.0
+      lodash.kebabcase: 4.1.1
+      requireindex: 1.2.0
+      snake-case: 3.0.4
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.23.0(eslint@9.20.0)(typescript@5.7.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+
   eslint-plugin-es-x@7.8.0(eslint@9.20.0):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.20.0)
@@ -2751,6 +3245,13 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.0.1(eslint@9.20.0)
 
+  eslint-plugin-qunit@8.1.2(eslint@9.20.0):
+    dependencies:
+      eslint-utils: 3.0.0(eslint@9.20.0)
+      requireindex: 1.2.0
+    transitivePeerDependencies:
+      - eslint
+
   eslint-plugin-simple-import-sort@12.1.1(eslint@9.20.0):
     dependencies:
       eslint: 9.20.0
@@ -2771,10 +3272,20 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
+  eslint-scope@7.2.2:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
   eslint-scope@8.2.0:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
+
+  eslint-utils@3.0.0(eslint@9.20.0):
+    dependencies:
+      eslint: 9.20.0
+      eslint-visitor-keys: 2.1.0
 
   eslint-visitor-keys@2.1.0: {}
 
@@ -2997,6 +3508,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-tags@3.3.1: {}
+
   human-id@1.0.2: {}
 
   iconv-lite@0.4.24:
@@ -3102,6 +3615,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.camelcase@4.3.0: {}
+
+  lodash.kebabcase@4.1.1: {}
+
   lodash.merge@4.6.2: {}
 
   lodash.startcase@4.4.0: {}
@@ -3113,6 +3630,10 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  lower-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
@@ -3123,6 +3644,10 @@ snapshots:
     dependencies:
       '@types/minimatch': 3.0.5
       minimatch: 3.1.2
+
+  mathml-tag-names@2.1.3: {}
+
+  mdn-data@2.12.2: {}
 
   merge2@1.4.1: {}
 
@@ -3149,9 +3674,16 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nanoid@3.3.8: {}
+
   natural-compare-lite@1.4.0: {}
 
   natural-compare@1.4.0: {}
+
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.8.1
 
   node-fetch@2.7.0:
     dependencies:
@@ -3239,6 +3771,16 @@ snapshots:
 
   pify@4.0.1: {}
 
+  postcss-sorting@8.0.2(postcss@8.5.1):
+    dependencies:
+      postcss: 8.5.1
+
+  postcss@8.5.1:
+    dependencies:
+      nanoid: 3.3.8
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.0:
@@ -3285,6 +3827,8 @@ snapshots:
   regenerator-runtime@0.14.1: {}
 
   require-directory@2.1.1: {}
+
+  requireindex@1.2.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -3337,6 +3881,13 @@ snapshots:
 
   slash@3.0.0: {}
 
+  snake-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
+
+  source-map-js@1.2.1: {}
+
   source-map@0.6.1: {}
 
   spawndamnit@3.0.1:
@@ -3376,6 +3927,22 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  stylelint-config-recommended@15.0.0: {}
+
+  stylelint-config-standard@37.0.0:
+    dependencies:
+      stylelint-config-recommended: 15.0.0
+
+  stylelint-order@6.0.4:
+    dependencies:
+      postcss: 8.5.1
+      postcss-sorting: 8.0.2(postcss@8.5.1)
+
+  stylelint-prettier@5.0.3(prettier@3.5.0):
+    dependencies:
+      prettier: 3.5.0
+      prettier-linter-helpers: 1.0.0
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -3385,6 +3952,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svg-tags@1.0.0: {}
 
   synckit@0.9.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - configs/**
   - packages/analyze-ember-project-dependencies
   - packages/blueprints-v2-addon
   - packages/create-v2-addon-repo


### PR DESCRIPTION
## Background

In order to lint `blueprints-v2-addon` (an intermediary package), the `configs` folder with package names `@shared-configs/*` needs to exist.

