### PR TITLE
Pinned ember-page-title to v8 (ember-lts-3.28)

### DIFF
--- a/.changeset/pink-days-ask.md
+++ b/.changeset/pink-days-ask.md
@@ -1,0 +1,5 @@
+---
+"create-v2-addon-repo": patch
+---
+
+Pinned ember-page-title to v8 (ember-lts-3.28)

--- a/packages/create-v2-addon-repo/src/blueprints/test-app/config/ember-try.js
+++ b/packages/create-v2-addon-repo/src/blueprints/test-app/config/ember-try.js
@@ -24,6 +24,7 @@ module.exports = async function () {
       //       '@types/ember-qunit': '6.1.1',
       //       'ember-a11y-testing': '5.2.1',
       //       'ember-cli': '~3.28.0',
+      //       'ember-page-title': '8.2.3',
       //       'ember-qunit': '6.0.0',
       //       'ember-resolver': '11.0.1',
       //       'ember-source': '~3.28.0',

--- a/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/test-app/config/ember-try.js
+++ b/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/test-app/config/ember-try.js
@@ -24,6 +24,7 @@ module.exports = async function () {
       //       '@types/ember-qunit': '6.1.1',
       //       'ember-a11y-testing': '5.2.1',
       //       'ember-cli': '~3.28.0',
+      //       'ember-page-title': '8.2.3',
       //       'ember-qunit': '6.0.0',
       //       'ember-resolver': '11.0.1',
       //       'ember-source': '~3.28.0',


### PR DESCRIPTION
## Background

Patches #78. `ember-page-title@v9` replaced `inject as service`, which causes an error to be thrown on Ember 3.28 (no longer supported):

```sh
Cannot access 'PageTitle' before initialization
```

