### PR TITLE
Fixed lint errors

### DIFF
--- a/.changeset/silent-teeth-jam.md
+++ b/.changeset/silent-teeth-jam.md
@@ -1,0 +1,6 @@
+---
+"create-v2-addon-repo": minor
+"blueprints-v2-addon": minor
+---
+
+Fixed lint errors

--- a/packages/blueprints-v2-addon/eslint.config.mjs
+++ b/packages/blueprints-v2-addon/eslint.config.mjs
@@ -14,14 +14,6 @@ export default [
     ],
   },
   {
-    files: ['**/*.ts'],
-    rules: {
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-    },
-  },
-  {
     files: ['update-blueprints.mjs'],
     rules: {
       'n/hashbang': 'off',

--- a/packages/blueprints-v2-addon/package.json
+++ b/packages/blueprints-v2-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprints-v2-addon",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "description": "Blueprints for v2 addons",
   "keywords": [

--- a/packages/blueprints-v2-addon/src/steps/run-destroy/update-addon/update-barrel-file.ts
+++ b/packages/blueprints-v2-addon/src/steps/run-destroy/update-addon/update-barrel-file.ts
@@ -12,8 +12,11 @@ function removeExportStatement(file: string, options: Options): string {
 
   const ast = traverse(file, {
     visitExportNamedDeclaration(path) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const resource = path.value.source.value as string;
+      if (!path.node.source) {
+        return false;
+      }
+
+      const resource = path.node.source.value as string;
 
       if (resource.startsWith(`./${entity.type}s/${entity.name}`)) {
         return null;

--- a/packages/blueprints-v2-addon/src/steps/run-destroy/update-addon/update-barrel-file.ts
+++ b/packages/blueprints-v2-addon/src/steps/run-destroy/update-addon/update-barrel-file.ts
@@ -12,6 +12,7 @@ function removeExportStatement(file: string, options: Options): string {
 
   const ast = traverse(file, {
     visitExportNamedDeclaration(path) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const resource = path.value.source.value as string;
 
       if (resource.startsWith(`./${entity.type}s/${entity.name}`)) {

--- a/packages/blueprints-v2-addon/src/steps/run-destroy/update-addon/update-template-registry.ts
+++ b/packages/blueprints-v2-addon/src/steps/run-destroy/update-addon/update-template-registry.ts
@@ -19,9 +19,11 @@ function removeImportStatement(
 
   const ast = traverse(file, {
     visitImportDeclaration(path) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const resource = path.value.source.value as string;
 
       if (resource.startsWith(`./${entity.type}s/${entity.name}`)) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         localName = path.value.specifiers[0].local.name;
 
         return null;
@@ -42,18 +44,23 @@ function updateRegistry(file: string, localName: string | undefined): string {
 
   const ast = traverse(file, {
     visitExportDefaultDeclaration(path) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const registry = path.value.declaration;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const registryEntries = registry.body.body;
 
       // @ts-expect-error: Assume that types from external packages are correct
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       registry.body.body = registryEntries.filter((registryEntry) => {
         if (
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           registryEntry.typeAnnotation.typeAnnotation.type !== 'TSTypeQuery'
         ) {
           return true;
         }
 
         return (
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           registryEntry.typeAnnotation.typeAnnotation.exprName.name !==
           localName
         );

--- a/packages/blueprints-v2-addon/src/steps/run-destroy/update-addon/update-template-registry.ts
+++ b/packages/blueprints-v2-addon/src/steps/run-destroy/update-addon/update-template-registry.ts
@@ -15,16 +15,16 @@ function removeImportStatement(
   const { entity } = options;
 
   const traverse = AST.traverse(true);
-  let localName;
+  let localName: string | undefined;
 
   const ast = traverse(file, {
     visitImportDeclaration(path) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const resource = path.value.source.value as string;
+      const resource = path.node.source.value as string;
 
       if (resource.startsWith(`./${entity.type}s/${entity.name}`)) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        localName = path.value.specifiers[0].local.name;
+        const specifiers = path.node.specifiers ?? [];
+
+        localName = specifiers[0]?.local?.name as string | undefined;
 
         return null;
       }
@@ -44,23 +44,21 @@ function updateRegistry(file: string, localName: string | undefined): string {
 
   const ast = traverse(file, {
     visitExportDefaultDeclaration(path) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const registry = path.value.declaration;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const registryEntries = registry.body.body;
+      const registry = path.node.declaration;
 
-      // @ts-expect-error: Assume that types from external packages are correct
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      registry.body.body = registryEntries.filter((registryEntry) => {
+      if (registry.type !== 'TSInterfaceDeclaration') {
+        return false;
+      }
+
+      registry.body.body = registry.body.body.filter((registryEntry) => {
         if (
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          registryEntry.typeAnnotation.typeAnnotation.type !== 'TSTypeQuery'
+          registryEntry.typeAnnotation?.typeAnnotation?.type !== 'TSTypeQuery'
         ) {
           return true;
         }
 
         return (
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          // @ts-expect-error: Incorrect type
           registryEntry.typeAnnotation.typeAnnotation.exprName.name !==
           localName
         );

--- a/packages/blueprints-v2-addon/src/steps/run-generate/update-addon/update-template-registry.ts
+++ b/packages/blueprints-v2-addon/src/steps/run-generate/update-addon/update-template-registry.ts
@@ -62,13 +62,13 @@ function updateRegistry(file: string, options: Options): string {
 
   const ast = traverse(file, {
     visitExportDefaultDeclaration(path) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const registry = path.value.declaration;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const registryEntries = registry.body.body;
+      const registry = path.node.declaration;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      registryEntries.splice(
+      if (registry.type !== 'TSInterfaceDeclaration') {
+        return false;
+      }
+
+      registry.body.body.splice(
         0,
         0,
         AST.builders.tsPropertySignature(
@@ -80,8 +80,7 @@ function updateRegistry(file: string, options: Options): string {
       );
 
       if (entity.type === 'component') {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-        registryEntries.splice(
+        registry.body.body.splice(
           0,
           0,
           AST.builders.tsPropertySignature(

--- a/packages/blueprints-v2-addon/src/steps/run-generate/update-addon/update-template-registry.ts
+++ b/packages/blueprints-v2-addon/src/steps/run-generate/update-addon/update-template-registry.ts
@@ -62,9 +62,12 @@ function updateRegistry(file: string, options: Options): string {
 
   const ast = traverse(file, {
     visitExportDefaultDeclaration(path) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const registry = path.value.declaration;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const registryEntries = registry.body.body;
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       registryEntries.splice(
         0,
         0,
@@ -77,6 +80,7 @@ function updateRegistry(file: string, options: Options): string {
       );
 
       if (entity.type === 'component') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         registryEntries.splice(
           0,
           0,

--- a/packages/blueprints-v2-addon/src/steps/run-new/update-docs-and-test-apps/update-package-json.ts
+++ b/packages/blueprints-v2-addon/src/steps/run-new/update-docs-and-test-apps/update-package-json.ts
@@ -21,6 +21,7 @@ function updateDevDependencies(
 
   devDependencies.set(addon.name, 'workspace:*');
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   packageJson['devDependencies'] = convertToObject(devDependencies);
 }
 

--- a/packages/blueprints-v2-addon/update-blueprints.mjs
+++ b/packages/blueprints-v2-addon/update-blueprints.mjs
@@ -6,7 +6,7 @@ import gitDiffApply from 'git-diff-apply';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-const CURRENT_VERSION = '3.0.0';
+const CURRENT_VERSION = '3.1.0';
 
 async function updateBlueprints({ from, to }) {
   const startTag = from;

--- a/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/eslint.config.mjs
+++ b/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/eslint.config.mjs
@@ -14,14 +14,6 @@ export default [
     ],
   },
   {
-    files: ['**/*.ts'],
-    rules: {
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-    },
-  },
-  {
     files: ['update-blueprints.mjs'],
     rules: {
       'n/hashbang': 'off',

--- a/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/package.json
+++ b/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprints-v2-addon",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "description": "Blueprints for v2 addons",
   "keywords": [

--- a/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/src/steps/run-destroy/update-addon/update-barrel-file.ts
+++ b/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/src/steps/run-destroy/update-addon/update-barrel-file.ts
@@ -12,7 +12,11 @@ function removeExportStatement(file: string, options: Options): string {
 
   const ast = traverse(file, {
     visitExportNamedDeclaration(path) {
-      const resource = path.value.source.value as string;
+      if (!path.node.source) {
+        return false;
+      }
+
+      const resource = path.node.source.value as string;
 
       if (resource.startsWith(`./${entity.type}s/${entity.name}`)) {
         return null;

--- a/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/src/steps/run-destroy/update-addon/update-template-registry.ts
+++ b/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/src/steps/run-destroy/update-addon/update-template-registry.ts
@@ -15,14 +15,16 @@ function removeImportStatement(
   const { entity } = options;
 
   const traverse = AST.traverse(true);
-  let localName;
+  let localName: string | undefined;
 
   const ast = traverse(file, {
     visitImportDeclaration(path) {
-      const resource = path.value.source.value as string;
+      const resource = path.node.source.value as string;
 
       if (resource.startsWith(`./${entity.type}s/${entity.name}`)) {
-        localName = path.value.specifiers[0].local.name;
+        const specifiers = path.node.specifiers ?? [];
+
+        localName = specifiers[0]?.local?.name as string | undefined;
 
         return null;
       }
@@ -42,18 +44,21 @@ function updateRegistry(file: string, localName: string | undefined): string {
 
   const ast = traverse(file, {
     visitExportDefaultDeclaration(path) {
-      const registry = path.value.declaration;
-      const registryEntries = registry.body.body;
+      const registry = path.node.declaration;
 
-      // @ts-expect-error: Assume that types from external packages are correct
-      registry.body.body = registryEntries.filter((registryEntry) => {
+      if (registry.type !== 'TSInterfaceDeclaration') {
+        return false;
+      }
+
+      registry.body.body = registry.body.body.filter((registryEntry) => {
         if (
-          registryEntry.typeAnnotation.typeAnnotation.type !== 'TSTypeQuery'
+          registryEntry.typeAnnotation?.typeAnnotation?.type !== 'TSTypeQuery'
         ) {
           return true;
         }
 
         return (
+          // @ts-expect-error: Incorrect type
           registryEntry.typeAnnotation.typeAnnotation.exprName.name !==
           localName
         );

--- a/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/src/steps/run-generate/update-addon/update-template-registry.ts
+++ b/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/src/steps/run-generate/update-addon/update-template-registry.ts
@@ -62,10 +62,13 @@ function updateRegistry(file: string, options: Options): string {
 
   const ast = traverse(file, {
     visitExportDefaultDeclaration(path) {
-      const registry = path.value.declaration;
-      const registryEntries = registry.body.body;
+      const registry = path.node.declaration;
 
-      registryEntries.splice(
+      if (registry.type !== 'TSInterfaceDeclaration') {
+        return false;
+      }
+
+      registry.body.body.splice(
         0,
         0,
         AST.builders.tsPropertySignature(
@@ -77,7 +80,7 @@ function updateRegistry(file: string, options: Options): string {
       );
 
       if (entity.type === 'component') {
-        registryEntries.splice(
+        registry.body.body.splice(
           0,
           0,
           AST.builders.tsPropertySignature(

--- a/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/src/steps/run-new/update-docs-and-test-apps/update-package-json.ts
+++ b/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/src/steps/run-new/update-docs-and-test-apps/update-package-json.ts
@@ -21,6 +21,7 @@ function updateDevDependencies(
 
   devDependencies.set(addon.name, 'workspace:*');
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   packageJson['devDependencies'] = convertToObject(devDependencies);
 }
 

--- a/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/update-blueprints.mjs
+++ b/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/update-blueprints.mjs
@@ -6,7 +6,7 @@ import gitDiffApply from 'git-diff-apply';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-const CURRENT_VERSION = '3.0.0';
+const CURRENT_VERSION = '3.1.0';
 
 async function updateBlueprints({ from, to }) {
   const startTag = from;

--- a/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/eslint.config.mjs
+++ b/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/eslint.config.mjs
@@ -14,14 +14,6 @@ export default [
     ],
   },
   {
-    files: ['**/*.ts'],
-    rules: {
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-    },
-  },
-  {
     files: ['update-blueprints.mjs'],
     rules: {
       'n/hashbang': 'off',

--- a/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/package.json
+++ b/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprints-v2-addon",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "description": "Blueprints for v2 addons",
   "keywords": [

--- a/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/src/steps/run-destroy/update-addon/update-barrel-file.ts
+++ b/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/src/steps/run-destroy/update-addon/update-barrel-file.ts
@@ -12,7 +12,11 @@ function removeExportStatement(file: string, options: Options): string {
 
   const ast = traverse(file, {
     visitExportNamedDeclaration(path) {
-      const resource = path.value.source.value as string;
+      if (!path.node.source) {
+        return false;
+      }
+
+      const resource = path.node.source.value as string;
 
       if (resource.startsWith(`./${entity.type}s/${entity.name}`)) {
         return null;

--- a/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/src/steps/run-destroy/update-addon/update-template-registry.ts
+++ b/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/src/steps/run-destroy/update-addon/update-template-registry.ts
@@ -15,14 +15,16 @@ function removeImportStatement(
   const { entity } = options;
 
   const traverse = AST.traverse(true);
-  let localName;
+  let localName: string | undefined;
 
   const ast = traverse(file, {
     visitImportDeclaration(path) {
-      const resource = path.value.source.value as string;
+      const resource = path.node.source.value as string;
 
       if (resource.startsWith(`./${entity.type}s/${entity.name}`)) {
-        localName = path.value.specifiers[0].local.name;
+        const specifiers = path.node.specifiers ?? [];
+
+        localName = specifiers[0]?.local?.name as string | undefined;
 
         return null;
       }
@@ -42,18 +44,21 @@ function updateRegistry(file: string, localName: string | undefined): string {
 
   const ast = traverse(file, {
     visitExportDefaultDeclaration(path) {
-      const registry = path.value.declaration;
-      const registryEntries = registry.body.body;
+      const registry = path.node.declaration;
 
-      // @ts-expect-error: Assume that types from external packages are correct
-      registry.body.body = registryEntries.filter((registryEntry) => {
+      if (registry.type !== 'TSInterfaceDeclaration') {
+        return false;
+      }
+
+      registry.body.body = registry.body.body.filter((registryEntry) => {
         if (
-          registryEntry.typeAnnotation.typeAnnotation.type !== 'TSTypeQuery'
+          registryEntry.typeAnnotation?.typeAnnotation?.type !== 'TSTypeQuery'
         ) {
           return true;
         }
 
         return (
+          // @ts-expect-error: Incorrect type
           registryEntry.typeAnnotation.typeAnnotation.exprName.name !==
           localName
         );

--- a/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/src/steps/run-generate/update-addon/update-template-registry.ts
+++ b/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/src/steps/run-generate/update-addon/update-template-registry.ts
@@ -62,10 +62,13 @@ function updateRegistry(file: string, options: Options): string {
 
   const ast = traverse(file, {
     visitExportDefaultDeclaration(path) {
-      const registry = path.value.declaration;
-      const registryEntries = registry.body.body;
+      const registry = path.node.declaration;
 
-      registryEntries.splice(
+      if (registry.type !== 'TSInterfaceDeclaration') {
+        return false;
+      }
+
+      registry.body.body.splice(
         0,
         0,
         AST.builders.tsPropertySignature(
@@ -77,7 +80,7 @@ function updateRegistry(file: string, options: Options): string {
       );
 
       if (entity.type === 'component') {
-        registryEntries.splice(
+        registry.body.body.splice(
           0,
           0,
           AST.builders.tsPropertySignature(

--- a/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/src/steps/run-new/update-docs-and-test-apps/update-package-json.ts
+++ b/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/src/steps/run-new/update-docs-and-test-apps/update-package-json.ts
@@ -21,6 +21,7 @@ function updateDevDependencies(
 
   devDependencies.set(addon.name, 'workspace:*');
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   packageJson['devDependencies'] = convertToObject(devDependencies);
 }
 

--- a/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/update-blueprints.mjs
+++ b/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/update-blueprints.mjs
@@ -6,7 +6,7 @@ import gitDiffApply from 'git-diff-apply';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-const CURRENT_VERSION = '3.0.0';
+const CURRENT_VERSION = '3.1.0';
 
 async function updateBlueprints({ from, to }) {
   const startTag = from;


### PR DESCRIPTION
## Background

Incorrect use of `recast` had led to unnecessary type errors. In general, `node.value` should have read `path.node` instead.
