### PR TITLE
Re-released 4.1.0

### DIFF
--- a/.changeset/gentle-ideas-travel.md
+++ b/.changeset/gentle-ideas-travel.md
@@ -1,0 +1,6 @@
+---
+"create-v2-addon-repo": patch
+"blueprints-v2-addon": patch
+---
+
+Re-released 4.1.0

--- a/packages/blueprints-v2-addon/package.json
+++ b/packages/blueprints-v2-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprints-v2-addon",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "private": true,
   "description": "Blueprints for v2 addons",
   "keywords": [

--- a/packages/blueprints-v2-addon/update-blueprints.mjs
+++ b/packages/blueprints-v2-addon/update-blueprints.mjs
@@ -6,7 +6,7 @@ import gitDiffApply from 'git-diff-apply';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-const CURRENT_VERSION = '4.1.0';
+const CURRENT_VERSION = '4.1.1';
 
 async function updateBlueprints({ from, to }) {
   const startTag = from;

--- a/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/package.json
+++ b/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprints-v2-addon",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "private": true,
   "description": "Blueprints for v2 addons",
   "keywords": [

--- a/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/update-blueprints.mjs
+++ b/packages/create-v2-addon-repo/src/blueprints/blueprints/v2-addon/update-blueprints.mjs
@@ -6,7 +6,7 @@ import gitDiffApply from 'git-diff-apply';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-const CURRENT_VERSION = '4.1.0';
+const CURRENT_VERSION = '4.1.1';
 
 async function updateBlueprints({ from, to }) {
   const startTag = from;

--- a/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/package.json
+++ b/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprints-v2-addon",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "private": true,
   "description": "Blueprints for v2 addons",
   "keywords": [

--- a/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/update-blueprints.mjs
+++ b/packages/create-v2-addon-repo/tests/fixtures/typescript/output/my-repo/blueprints/v2-addon/update-blueprints.mjs
@@ -6,7 +6,7 @@ import gitDiffApply from 'git-diff-apply';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-const CURRENT_VERSION = '4.1.0';
+const CURRENT_VERSION = '4.1.1';
 
 async function updateBlueprints({ from, to }) {
   const startTag = from;


### PR DESCRIPTION
## Background

Patches #139 and https://github.com/ijlee2/create-v2-addon-repo/commit/f198944e267ebed143c26a94999298defda1e5a8, where I had mistakenly released the patch version `4.0.1` while creating the tag `4.1.0`.
